### PR TITLE
Fix for help string readability if keyword > 16 char

### DIFF
--- a/third-party/bigcode/uCli/module/src/ucli_module.c
+++ b/third-party/bigcode/uCli/module/src/ucli_module.c
@@ -233,7 +233,7 @@ ucli_module_help(ucli_module_t* mod, aim_pvs_t* pvs)
     }
 
     BIGLIST_FOREACH_DATA(ble, mod->command_list, ucli_command_t*, cp) {
-        aim_printf(pvs, "  %-16s%s\n",
+        aim_printf(pvs, "  %-16s %s\n",
                    cp->command, cp->help.summary ? cp->help.summary : "");
     }
 


### PR DESCRIPTION
* If the keyword is more than 16 chars, the keyword and helpstring gets printed without any space in between and hence reduce readability