### PR TITLE
Fix Crash while quitting from shell

### DIFF
--- a/third-party/klish/clish/shell/shell_new.c
+++ b/third-party/klish/clish/shell/shell_new.c
@@ -192,7 +192,6 @@ static void clish_shell_fini(clish_shell_t *this)
 
 	lub_string_free(this->lockfile);
 	lub_string_free(this->default_shebang);
-	lub_free(this->user);
 	if (this->fifo_temp)
 		lub_string_free(this->fifo_temp);
 }


### PR DESCRIPTION
this->user points to a static memory and it cant be passed to free. This is causing crash while exiting from shell/clish.

For more info "man getpwuid" which says "Do not pass the returned pointer to free"