### PR TITLE
coverity issues for bigcode

### DIFF
--- a/third-party/bigcode/AIM/module/src/aim_printf.c
+++ b/third-party/bigcode/AIM/module/src/aim_printf.c
@@ -269,6 +269,7 @@ aim_vprintf(aim_pvs_t* pvs, const char* fmt, va_list _vargs)
         count += aim_pvs_vprintf(pvs, fmt_, vargs.val);
     }
     aim_free(fmt_);
+    va_end(vargs.val);
     return count;
 }
 

--- a/third-party/bigcode/AIM/module/src/aim_rl.c
+++ b/third-party/bigcode/AIM/module/src/aim_rl.c
@@ -63,7 +63,7 @@ uint64_t
 aim_ratelimiter_next_allowed_time(aim_ratelimiter_t* rl)
 {
     if(rl) {
-        uint64_t burst_time = rl->burst * rl->interval;
+        uint64_t burst_time = ((uint64_t) rl->burst * rl->interval);
         /* Avoid integer underflow */
         if (rl->empty_time < burst_time) {
             return 0;

--- a/third-party/bigcode/uCli/module/src/ucli.c
+++ b/third-party/bigcode/uCli/module/src/ucli.c
@@ -624,6 +624,7 @@ ucli_dispatch_filep(ucli_t* ucli, aim_pvs_t* pvs, FILE* fp)
             aim_printf(pvs, "[ '%s' ]\n", line);
             rv = ucli_dispatch_string(ucli, pvs, line);
         }
+    free(line);
     }
     return rv;
 }

--- a/third-party/bigcode/uCli/module/src/ucli.c
+++ b/third-party/bigcode/uCli/module/src/ucli.c
@@ -624,7 +624,7 @@ ucli_dispatch_filep(ucli_t* ucli, aim_pvs_t* pvs, FILE* fp)
             aim_printf(pvs, "[ '%s' ]\n", line);
             rv = ucli_dispatch_string(ucli, pvs, line);
         }
-    free(line);
+    aim_free(line);
     }
     return rv;
 }

--- a/third-party/bigcode/uCli/module/src/ucli_handlers.c
+++ b/third-party/bigcode/uCli/module/src/ucli_handlers.c
@@ -124,8 +124,7 @@ void ucli_log_file_open(char *fname, ucli_context_t* uc)
     aim_pvs_t* tmp_pvs = NULL;
     tmp_pvs = aim_pvs_fopen(fname, "a");
     uc->pvs = *tmp_pvs;
-    tmp_pvs=NULL;
-    free(tmp_pvs);
+    aim_free(tmp_pvs);
 }
 
 void ucli_log_file_close(ucli_context_t* uc)
@@ -134,7 +133,7 @@ void ucli_log_file_close(ucli_context_t* uc)
 }
 static ucli_status_t
 ucli_ucli_mlog__set__(ucli_context_t* uc)
-{
+{	
     const char* module_name;
     aim_log_t* lobj;
     char* f = NULL;

--- a/third-party/bigcode/uCli/module/src/ucli_handlers.c
+++ b/third-party/bigcode/uCli/module/src/ucli_handlers.c
@@ -124,6 +124,8 @@ void ucli_log_file_open(char *fname, ucli_context_t* uc)
     aim_pvs_t* tmp_pvs = NULL;
     tmp_pvs = aim_pvs_fopen(fname, "a");
     uc->pvs = *tmp_pvs;
+    tmp_pvs=NULL;
+    free(tmp_pvs);
 }
 
 void ucli_log_file_close(ucli_context_t* uc)


### PR DESCRIPTION
aim_printf.c  
Missing varargs init or cleanup (VARARGS)
 missing_va_end: va_end was not called for vargs.val.

third-party/bigcode/AIM/module/src/aim_rl.c
overflow_before_widen: Potentially overflowing expression rl->burst * rl->interval with type unsigned int (32 bits, unsigned) is evaluated using 32-bit arithmetic, and then used in a context that expects an expression of type uint64_t (64 bits, unsigned).

third-party/bigcode/uCli/module/src/ucli.c
noescape: Resource line is not freed or pointed-to in fgets.

third-party/bigcode/uCli/module/src/ucli_handlers.c
leaked_storage: Variable tmp_pvs going out of scope leaks the storage it points to
so assign null to variable before function ends