### PR TITLE
Prototype missing for lub_db_getpwnam causing address truncation

### DIFF
--- a/cmake/ConfigureChecks.cmake
+++ b/cmake/ConfigureChecks.cmake
@@ -42,6 +42,8 @@ check_include_file(sched.h HAVE_SCHED_H)
 check_include_file(strings.h HAVE_STRINGS_H)
 check_include_file(string.h HAVE_STRING_H)
 check_include_file(pcap/pcap.h HAVE_PCAP_H)
+check_include_file(pwd.h HAVE_PWD_H)
+check_include_file(grp.h HAVE_GRP_H)
 
 check_function_exists(clock_gettime HAVE_CLOCK_GETTIME)
 check_function_exists(floor HAVE_FLOOR)

--- a/cmake/config.h.cmake
+++ b/cmake/config.h.cmake
@@ -144,6 +144,12 @@
 /* Define to 1 if you have the <pcap/pcap.h> header file. */
 #cmakedefine HAVE_PCAP_H 1
 
+/* Define to 1 if you have the <pwd.h> header file. */
+#cmakedefine HAVE_PWD_H 1
+
+/* Define to 1 if you have the <grp.h> header file. */
+#cmakedefine HAVE_GRP_H 1
+
 /*************************** FUNCTIONS ***************************/
 
 /* Define to 1 if you have the `clock_gettime' function. */


### PR DESCRIPTION
The prototype is missing for lub_db_getpwnam if HAVE_PWD_H is not defined causing the address to be truncated to 32 bit, causing a crash while freeing/trying to access this memory.